### PR TITLE
fix(golang): correct golang package

### DIFF
--- a/go-server/Earthfile
+++ b/go-server/Earthfile
@@ -5,7 +5,7 @@ WORKDIR /kvserver
 kvserver:
     COPY go.mod go.sum ./
     RUN go mod download
-    COPY ../proto+proto-go/go-pb kvapi
+    COPY ../proto+proto-go/go-pb ./
     COPY --dir cmd ./
     RUN go build -o kvserver cmd/server/main.go
     SAVE ARTIFACT kvserver

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 package simplekeyvalue;
-option go_package = "kvapi";
+option go_package = "/kvapi";
 
 // The greeting service definition.
 service KeyValue {


### PR DESCRIPTION
Looks like this fixes [1].

[1] https://github.com/earthly/example-grpc-key-value-store/issues/1