### PR TITLE
feat(go): target to output the gRPC-generated file

### DIFF
--- a/go-server/Earthfile
+++ b/go-server/Earthfile
@@ -5,7 +5,7 @@ WORKDIR /kvserver
 kvserver:
     COPY go.mod go.sum ./
     RUN go mod download
-    COPY ../proto+proto-go/go-pb kvapi
+    COPY ../proto+proto-go/go-pb ./
     COPY --dir cmd ./
     RUN go build -o kvserver cmd/server/main.go
     SAVE ARTIFACT kvserver

--- a/go-server/Earthfile
+++ b/go-server/Earthfile
@@ -5,10 +5,18 @@ WORKDIR /kvserver
 kvserver:
     COPY go.mod go.sum ./
     RUN go mod download
+    RUN rm -fr kvapi
     COPY ../proto+proto-go/go-pb ./
     COPY --dir cmd ./
     RUN go build -o kvserver cmd/server/main.go
     SAVE ARTIFACT kvserver
+
+kvserver-dev:
+    # Call this if you'd like to develop using local Golang tooling outside of
+    # Earthly.
+    FROM scratch
+    COPY ../proto+proto-go/go-pb ./
+    SAVE ARTIFACT kvapi AS LOCAL kvapi
 
 kvserver-docker:
     FROM alpine:latest

--- a/proto/api.proto
+++ b/proto/api.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 package simplekeyvalue;
-option go_package = "kvapi";
+option go_package = "/kvapi";
 
 // The greeting service definition.
 service KeyValue {


### PR DESCRIPTION
 This is useful to `go doc` the generated file and to also make the project not be "red" in an IDE.