### PR TITLE
Fix comment for GetRequest

### DIFF
--- a/proto/api.proto
+++ b/proto/api.proto
@@ -19,7 +19,7 @@ message SetRequest {
 message SetReply {
 }
 
-// GetRequest contains a key and value to set
+// GetRequest contains a key to retrieve
 message GetRequest {
   string key = 1;
 }


### PR DESCRIPTION
The comment for the GetRequest message type did not match the contents/purpose of the message.