### PR TITLE
Fix go server and add integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: GitHub Actions CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  tests:
+    name: +test
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 1
+      EARTHLY_CONVERSION_PARALLELISM: "5"
+      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
+      EARTHLY_INSTALL_ID: "earthly-githubactions"
+    steps:
+      - uses: earthly/actions/setup-earthly@v1
+      - uses: actions/checkout@v2
+      - name: Docker mirror login (non fork only)
+        run: docker login registry-1.docker.io.mirror.corp.earthly.dev --username "${{ secrets.DOCKERHUB_MIRROR_USERNAME }}" --password "${{ secrets.DOCKERHUB_MIRROR_PASSWORD }}"
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Configure Earthly to use mirror (non fork only)
+        run: |-
+          earthly config global.buildkit_additional_config "'[registry.\"docker.io\"]
+
+          mirrors = [\"registry-1.docker.io.mirror.corp.earthly.dev\"]'"
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: test example
+        run: earthly -P ./test+all

--- a/go-server/Earthfile
+++ b/go-server/Earthfile
@@ -5,7 +5,7 @@ WORKDIR /kvserver
 kvserver:
     COPY go.mod go.sum ./
     RUN go mod download
-    COPY ../proto+proto-go/go-pb ./
+    COPY ../proto+proto-go/kvapi kvapi
     COPY --dir cmd ./
     RUN go build -o kvserver cmd/server/main.go
     SAVE ARTIFACT kvserver

--- a/go-server/cmd/server/main.go
+++ b/go-server/cmd/server/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net"
 
-	pb "github.com/earthly/example-grpc-key-value-store/go-server/kvapi"
+	"github.com/earthly/example-grpc-key-value-store/go-server/kvapi"
 
 	"google.golang.org/grpc"
 )
@@ -19,24 +19,24 @@ var errKeyNotFound = fmt.Errorf("key not found")
 
 // server is used to implement kvapi.KeyValueServer
 type server struct {
-	pb.UnimplementedKeyValueServer
+	kvapi.UnimplementedKeyValueServer
 	data map[string]string
 }
 
 // Set stores a given value under a given key
-func (s *server) Set(ctx context.Context, in *pb.SetRequest) (*pb.SetReply, error) {
+func (s *server) Set(ctx context.Context, in *kvapi.SetRequest) (*kvapi.SetReply, error) {
 	key := in.GetKey()
 	value := in.GetValue()
 	log.Printf("serving set request for key %q and value %q", key, value)
 
 	s.data[key] = value
 
-	reply := &pb.SetReply{}
+	reply := &kvapi.SetReply{}
 	return reply, nil
 }
 
 // Get returns a value associated with a key to the client
-func (s *server) Get(ctx context.Context, in *pb.GetRequest) (*pb.GetReply, error) {
+func (s *server) Get(ctx context.Context, in *kvapi.GetRequest) (*kvapi.GetReply, error) {
 	key := in.GetKey()
 	log.Printf("serving get request for key %q", key)
 
@@ -45,7 +45,7 @@ func (s *server) Get(ctx context.Context, in *pb.GetRequest) (*pb.GetReply, erro
 		return nil, errKeyNotFound
 	}
 
-	reply := &pb.GetReply{
+	reply := &kvapi.GetReply{
 		Value: value,
 	}
 	return reply, nil
@@ -61,7 +61,7 @@ func main() {
 		data: make(map[string]string),
 	}
 	s := grpc.NewServer()
-	pb.RegisterKeyValueServer(s, &serverInstance)
+	kvapi.RegisterKeyValueServer(s, &serverInstance)
 	if err := s.Serve(lis); err != nil {
 		log.Fatalf("failed to serve: %v", err)
 	}

--- a/proto/Earthfile
+++ b/proto/Earthfile
@@ -16,7 +16,7 @@ proto-go:
   COPY api.proto /defs
   RUN mkdir /defs/go-api
   RUN protoc --proto_path=/defs --go_out=/defs/go-api --go-grpc_out=/defs/go-api /defs/api.proto
-  SAVE ARTIFACT ./go-api /go-pb AS LOCAL go-pb
+  SAVE ARTIFACT ./go-api/kvapi AS LOCAL kvapi
 
 proto-py:
   RUN apt-get install -y python3 python3-pip

--- a/test/Earthfile
+++ b/test/Earthfile
@@ -1,0 +1,20 @@
+all:
+    BUILD +test
+
+test:
+    FROM alpine:3.13
+    WITH DOCKER \
+       --load kvserver=../go-server+kvserver \
+       --load pyclient=../python-client+kvclient-docker \
+       --load rbclient=../ruby-client+kvclient-docker
+       RUN \
+           # start the server in the background
+           docker run --name=goserver -d --network=host kvserver:latest /kvserver/kvserver && \
+           # wait up to 5 seconds for server to start
+           timeout 5 /bin/sh -c 'until nc -z $0 $1; do sleep 1; done' localhost 50051 || ( echo "server failed to respond to tcp request"; exit 1) && \
+           # set a value via the python client
+           docker run --name=pyclient --network=host pyclient:latest python3 /kvclient/client.py weather=sunny && \
+           # fetch a value via the ruby client
+           docker run --name=rbclient --network=host rbclient:latest ruby /kvclient/client.rb weather > weather.value && \
+           test "$(cat weather.value)" = "sunny"
+    END


### PR DESCRIPTION
updates go server to use new location of generated proto buf code,
and adds an integration test under ./test+all

the test was intentially left out from the root +all target, as it
requires a -P (and I would rather not force users to initially run
the code with the -P mode as it might be their first time using
earthly).

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>