### PR TITLE
Change base image

### DIFF
--- a/proto/Earthfile
+++ b/proto/Earthfile
@@ -1,6 +1,7 @@
-FROM ubuntu:20.10
+FROM ubuntu
 WORKDIR /defs
 
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y wget unzip
 
 # setup protoc


### PR DESCRIPTION
apt-get was returning 404s, because 20.10 is no longer supported.

`ubuntu:latest` will always point to the latest LTS version and so the apt-get should never 404. ( Although you risk the distribution changing underneath you. )

For an example like this, I think using `:latest` might be the best way to keep it working. 

